### PR TITLE
chore: add rust-toolchain file

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,1 @@
+nightly


### PR DESCRIPTION
[rust-toolchain 파일](https://github.com/rust-lang/rustup#the-toolchain-file)은 개발자가 특정 툴체인을 사용하도록 설정하는 파일입니다. 본 프로젝트는 nightly를 사용하고 있으므로 이에 맞게 파일을 추가했습니다.